### PR TITLE
refactor: migrate to scss to math.div

### DIFF
--- a/css/functions/_aspect-ratio.scss
+++ b/css/functions/_aspect-ratio.scss
@@ -8,6 +8,8 @@
  *     }
  * }
  */
+@use "sass:math";
+
 @function aspect-ratio($name) {
-	@return percentage(map-deep-get($aspect-ratios, $name, height) / map-deep-get($aspect-ratios, $name, width));
+	@return percentage(math.div(map-deep-get($aspect-ratios, $name, height), map-deep-get($aspect-ratios, $name, width)));
 }

--- a/css/functions/_unit-helpers.scss
+++ b/css/functions/_unit-helpers.scss
@@ -2,16 +2,18 @@
  * Unit Helper Functions
  */
 
+@use "sass:math";
+
 @function px-to-em($px, $ref: $font-size_base) {
-	@return to-em(to-px($px) / to-px($ref));
+	@return to-em(math.div(to-px($px), to-px($ref)));
 }
 
 @function px-to-rem($px) {
-	@return to-rem(to-px($px) / to-px($font-size_base));
+	@return to-rem(math.div(to-px($px), to-px($font-size_base)));
 }
 
 @function px-to-px($px, $ref: $size_width-content) {
-	@return (to-px($px) / to-px($ref) * 100%);
+	@return (math.div(to-px($px), to-px($ref)) * 100%);
 }
 
 /* stylelint-disable length-zero-no-unit */
@@ -31,7 +33,7 @@
 
 @function strip-unit($number) {
 	@if type-of($number) == "number" and not unitless($number) {
-		@return $number / ($number * 0 + 1);
+		@return math.div($number, $number * 0 + 1);
 	}
 
 	@return $number;

--- a/css/mixins/_font-size.scss
+++ b/css/mixins/_font-size.scss
@@ -21,12 +21,14 @@
  * }
  */
 
+@use "sass:math";
+
 @mixin font-size($font-size, $line-height: $font-size) {
 	font-size: $font-size;
 
 	@if $line-height == auto {
 		line-height: $line-height-base;
 	} @else {
-		line-height: strip-unit($line-height / $font-size);
+		line-height: strip-unit(math.div($line-height, $font-size));
 	}
 }

--- a/css/mixins/_font-style-fluid.scss
+++ b/css/mixins/_font-style-fluid.scss
@@ -25,6 +25,8 @@
  * }
  */
 
+@use "sass:math";
+
 @mixin font-style-fluid($name) {
 	/* stylelint-disable length-zero-no-unit */
 	min-height: 0vw; /* Fix Safari bug with viewport units in calc() */
@@ -36,18 +38,18 @@
 		map-deep-get($font-styles, $name, font-style)
 	);
 
-	line-height: strip-unit(map-deep-get($font-styles, $name, small-line-height) / map-deep-get($font-styles, $name, small-font-size));
+	line-height: strip-unit(math.div(map-deep-get($font-styles, $name, small-line-height), map-deep-get($font-styles, $name, small-font-size)));
 
 	@include mq($from: medium) {
-		line-height: strip-unit(map-deep-get($font-styles, $name, medium-line-height) / map-deep-get($font-styles, $name, medium-font-size));
+		line-height: strip-unit(math.div(map-deep-get($font-styles, $name, medium-line-height), map-deep-get($font-styles, $name, medium-font-size)));
 	}
 
 	@include mq($from: large) {
-		line-height: strip-unit(map-deep-get($font-styles, $name, large-line-height) / map-deep-get($font-styles, $name, large-font-size));
+		line-height: strip-unit(math.div(map-deep-get($font-styles, $name, large-line-height), map-deep-get($font-styles, $name, large-font-size)));
 	}
 
 	@include mq($from: xlarge) {
-		line-height: strip-unit(map-deep-get($font-styles, $name, xlarge-line-height) / map-deep-get($font-styles, $name, xlarge-font-size));
+		line-height: strip-unit(math.div(map-deep-get($font-styles, $name, xlarge-line-height), map-deep-get($font-styles, $name, xlarge-font-size)));
 	}
 
 	@if map-deep-get($font-styles, $name, text-transform) != none {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swey/heyday-base",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Heyday Base CSS + JS\n",
   "repository": {
     "type": "git",


### PR DESCRIPTION
https://sass-lang.com/documentation/breaking-changes/slash-div

> Because Sass is a CSS superset, we’re matching CSS’s syntax by redefining / to be only a separator. / will be treated as a new type of list separator, similar to how , works today. Division will instead be written using the new math.div() function. This function will behave exactly the same as / does today.